### PR TITLE
resuming audio context with button

### DIFF
--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import ReactFlow, {
   Background,
   BackgroundVariant,
@@ -14,7 +14,11 @@ import Oscillator from "./components/Oscillator";
 import Destination from "./components/Destination";
 import Wire from "./components/Wire";
 import Visualizer from "./components/Visualizer";
-import { EditorContext, contextValue } from "./components/EditorContext";
+import {
+  EditorContext,
+  contextValue,
+  useEditorContext,
+} from "./components/EditorContext";
 
 const nodeTypes = {
   multiHandlesNode: MultiHandlesNode,
@@ -75,8 +79,10 @@ const onElementClick = (_event: any, element: any) =>
 const snapGrid: [number, number] = [20, 20];
 
 export const Editor = () => {
+  const { audioContext } = useEditorContext();
   const [reactflowInstance, setReactflowInstance] = useState(null);
   const [elements, setElements] = useState(initialElements);
+  const resumeBtn = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     setElements(elements);
@@ -108,8 +114,17 @@ export const Editor = () => {
     },
     [reactflowInstance]
   );
+
+  const onResumeAudioContext = useCallback(() => {
+    audioContext.resume();
+    resumeBtn?.current?.remove();
+  }, [audioContext]);
+
   return (
     <EditorContext.Provider value={contextValue}>
+      <button ref={resumeBtn} onClick={onResumeAudioContext}>
+        resume audio context
+      </button>
       <ReactFlow
         elements={elements}
         onElementClick={onElementClick}


### PR DESCRIPTION
<img width="1030" alt="Screenshot 2022-01-30 at 17 13 50" src="https://user-images.githubusercontent.com/156954/151707742-bf630bc1-4698-4068-830d-bada40bdc726.png">

use button to resume audio context so don't need to use console