### PR TITLE
add adsr graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "prismjs": "^1.28.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-envelope-graph": "^0.1.4",
     "react-flow-renderer": "^10.2.1",
     "react-icons": "^4.3.1",
     "react-piano": "^3.1.3",

--- a/src/components/ADSR.tsx
+++ b/src/components/ADSR.tsx
@@ -1,6 +1,8 @@
 import { LevaPanel, useControls, useCreateStore } from "leva";
 import { useEffect, FC } from "react";
 import { NodeProps } from "react-flow-renderer";
+// @ts-ignore
+import EnvelopeGraph from "react-envelope-graph";
 import useFlowNode from "../hooks/useFlowNode";
 import { LEVA_COLOR_ACCENT2_BLUE } from "../styles/consts";
 import { useNode } from "../ModuleContext";
@@ -12,12 +14,23 @@ interface ADSRData {
   values?: ADSRValues;
 }
 
+const MAX_ATTACK_VALUE = 10;
+const MAX_DECAY_VALUE = 10;
+const MAX_RELEASE_VALUE = 10;
+
+
 const ADSR: FC<NodeProps<ADSRData>> = ({ data, id }) => {
   const { updateNodeValues } = useFlowNode(id);
   const { node } = useNode<TADSR>(id);
   const store = useCreateStore();
 
-  const { attack = 0.1, attackCurve = 0.5, decay = 0, sustain = 1, release = 0 } = data.values || {};
+  const {
+    attack = 0.1,
+    attackCurve = 0.5,
+    decay = 0,
+    sustain = 1,
+    release = 0,
+  } = data.values || {};
 
   const values = useControls(
     "values",
@@ -25,7 +38,8 @@ const ADSR: FC<NodeProps<ADSRData>> = ({ data, id }) => {
       attack: {
         value: attack,
         min: 0,
-        max: 60,
+        max: MAX_ATTACK_VALUE,
+        step: 0.01,
         label: "attack",
       },
       attackCurve: {
@@ -37,19 +51,22 @@ const ADSR: FC<NodeProps<ADSRData>> = ({ data, id }) => {
       decay: {
         value: decay,
         min: 0,
-        max: 60,
+        max: MAX_DECAY_VALUE,
+        step: 0.01,
         label: "decay",
       },
       sustain: {
         value: sustain,
         min: 0,
         max: 1,
+        step: 0.01,
         label: "sustain",
       },
       release: {
         value: release,
         min: 0,
-        max: 60,
+        max: MAX_RELEASE_VALUE,
+        step: 0.01,
         label: "release",
       },
     },
@@ -62,6 +79,37 @@ const ADSR: FC<NodeProps<ADSRData>> = ({ data, id }) => {
 
   return (
     <Node id={id}>
+      <EnvelopeGraph
+        defaultXa={attack / MAX_ATTACK_VALUE}
+        defaultXd={decay / MAX_DECAY_VALUE}
+        defaultYa={1}
+        defaultYs={sustain}
+        defaultXr={release / MAX_RELEASE_VALUE}
+        ratio={{
+          xa: 0.25,
+          xd: 0.25,
+          xr: 0.25,
+        }}
+        style={{
+          backgroundColor: "#2a2d39",
+          height: "80px",
+          width: "100%",
+        }}
+        styles={{
+          line: {
+            fill: "none",
+            stroke: "#007bff",
+            strokeWidth: 2,
+          },
+          dndBox: {
+            stroke: "none",
+          },
+          dndBoxActive: {
+            fill: "blue",
+          },
+        }}
+        corners={false}
+      />
       <LevaPanel store={store} fill flat hideCopyButton titleBar={false} />
     </Node>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -12351,6 +12351,13 @@ react-element-to-jsx-string@^14.3.4:
     is-plain-object "5.0.0"
     react-is "17.0.2"
 
+react-envelope-graph@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/react-envelope-graph/-/react-envelope-graph-0.1.4.tgz#5e8f6cfb9c618c67a96eedb3ccd5741d82fb151a"
+  integrity sha512-nMaxcYv68NJ8fOM80T/MZlSMvgqx/4T7FduBUbKY2wUdkEvc0/K0fjfnwGuOxanXKc4boglwBbSMt2l4Hyv79A==
+  dependencies:
+    prop-types "^15.7.2"
+
 react-error-overlay@^6.0.10:
   version "6.0.10"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.10.tgz#0fe26db4fa85d9dbb8624729580e90e7159a59a6"


### PR DESCRIPTION
https://user-images.githubusercontent.com/1746575/185415634-fba7e906-f414-4a80-b0ad-5ffcbd6e3e88.mov

## Changes
- integrated [react-envelope-graph](https://github.com/TimDaub/react-envelope-graph)
- reduced max attack, decay and release values to `10`
- changed values step to `0.01`